### PR TITLE
match aws behavior for multi-attributes

### DIFF
--- a/src/main/scala/fakesdb/Data.scala
+++ b/src/main/scala/fakesdb/Data.scala
@@ -1,6 +1,7 @@
 package fakesdb
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.HashSet
 import scala.collection.mutable.LinkedHashMap
 import scala.collection.mutable.LinkedHashSet
 
@@ -30,6 +31,9 @@ class Item(val name: String) {
   def put(name: String, value: String, replace: Boolean): Unit = {
     this.getOrCreateAttribute(name).put(value, replace)
   }
+  def put(name: String, values: Seq[String], replace:Boolean) {
+    this.getOrCreateAttribute(name).put(values, replace)
+  }
   def delete(name: String): Unit = attributes.remove(name)
   def delete(name: String, value: String): Unit = {
     getAttribute(name) match {
@@ -43,16 +47,19 @@ class Item(val name: String) {
 }
 
 class Attribute(val name: String) {
-  private val values = new ListBuffer[String]()
+  private val values = new HashSet[String]()
   def getValues(): Iterator[String] = values.iterator
   def empty(): Boolean = values.size == 0
   def deleteValues(value: String) = {
-    while (values.contains(value)) {
-      values.remove(values.findIndexOf(_ == value))
-    }
+    values.remove(value)
   }
   def put(value: String, replace: Boolean) = {
     if (replace) values.clear
     values += value
+  }
+  
+  def put(_values: Seq[String], replace: Boolean) = {
+    if (replace) values.clear
+    values ++= _values
   }
 }

--- a/src/main/scala/fakesdb/FakeSdbServlet.scala
+++ b/src/main/scala/fakesdb/FakeSdbServlet.scala
@@ -32,7 +32,10 @@ class FakeSdbServlet extends HttpServlet {
     } catch {
       case e => {
         xml = toXML(e).toString
-        response.setStatus(400)
+        response.setStatus(e match {
+          case se: SDBException => se.httpStatus
+          case _ => 400
+        })
       }
     }
 

--- a/src/main/scala/fakesdb/actions/BatchPutAttributes.scala
+++ b/src/main/scala/fakesdb/actions/BatchPutAttributes.scala
@@ -1,23 +1,27 @@
 package fakesdb.actions
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.LinkedHashMap
 import scala.xml.NodeSeq
 import fakesdb._
+
 
 class BatchPutAttributes(data: Data) extends Action(data) {
 
   def handle(params: Params): NodeSeq = {
     val domain = parseDomain(params)
-    discoverAttributes(params).foreach((t: (String, String, String, Boolean)) => {
-      domain.getOrCreateItem(t._1).put(t._2, t._3, t._4)
-    })
+    discoverAttributes(params).foreach { case(item, attrs) => { 
+      attrs.foreach { case (name, attr) => {
+        domain.getOrCreateItem(item).put(name, attr.values, attr.replace)
+      }}
+      }}
     <BatchPutAttributesResponse xmlns={namespace}>
       {responseMetaData}
     </BatchPutAttributesResponse>
   }
 
-  private def discoverAttributes(params: Params): List[(String, String, String, Boolean)] = {
-    val attrs = new ListBuffer[(String, String, String, Boolean)]()
+  private def discoverAttributes(params: Params): LinkedHashMap[String, LinkedHashMap[String, AttributeUpdate]] = {
+    val attrs = new LinkedHashMap[String, LinkedHashMap[String, AttributeUpdate]]
     var i = 0
     var stop = false
     while (!stop) {
@@ -34,14 +38,16 @@ class BatchPutAttributes(data: Data) extends Action(data) {
           if (attrName.isEmpty || attrValue.isEmpty) {
             if (j > 1) stop2 = true
           } else {
-            attrs += ((itemName.get, attrName.get, attrValue.get, attrReplace.getOrElse("false").toBoolean))
+            val replace = attrReplace.getOrElse("false").toBoolean
+            val attr = attrs.getOrElseUpdate(itemName.get, new LinkedHashMap[String, AttributeUpdate]()).getOrElseUpdate(attrName.get, new AttributeUpdate(replace))
+            attr.values += attrValue.get
           }
           j += 1
         }
       }
       i += 1
     }
-    attrs.toList
+    attrs
   }
 
 }

--- a/src/main/scala/fakesdb/actions/ConditionalChecking.scala
+++ b/src/main/scala/fakesdb/actions/ConditionalChecking.scala
@@ -42,7 +42,7 @@ trait ConditionalChecking {
     None
   }
 
-  class ConditionalCheckFailedException(message: String) extends SDBException("ConditionalCheckFailed", message) {
+  class ConditionalCheckFailedException(message: String) extends SDBException("ConditionalCheckFailed", message, 409) {
     def this(condition: Tuple2[String, Option[String]]) = {
       this("Attribute (%s) value exists".format(condition._1))
     }
@@ -53,6 +53,6 @@ trait ConditionalChecking {
   }
 
   class AttributeDoesNotExistException(name: String)
-    extends SDBException("AttributeDoesNotExist", "Attribute (%s) does not exist".format(name))
+    extends SDBException("AttributeDoesNotExist", "Attribute (%s) does not exist".format(name), 404)
 
 }

--- a/src/main/scala/fakesdb/actions/Errors.scala
+++ b/src/main/scala/fakesdb/actions/Errors.scala
@@ -1,3 +1,3 @@
 package fakesdb.actions
 
-class SDBException(val code: String, val message: String) extends RuntimeException(message)
+class SDBException(val code: String, val message: String, val httpStatus: Int = 400) extends RuntimeException(message)

--- a/src/main/scala/fakesdb/actions/PutAttributes.scala
+++ b/src/main/scala/fakesdb/actions/PutAttributes.scala
@@ -1,6 +1,7 @@
 package fakesdb.actions
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.LinkedHashMap
 import scala.xml.NodeSeq
 import fakesdb._
 
@@ -8,28 +9,28 @@ class PutAttributes(data: Data) extends Action(data) with ConditionalChecking {
 
   def handle(params: Params): NodeSeq = {
     val domain = parseDomain(params)
-    val itemName = params.getOrElse("ItemName", error("No item name"))
+    val itemName = params.getOrElse("ItemName", throw new MissingItemNameException)
     val item = domain.getOrCreateItem(itemName)
 
     checkConditionals(item, params)
 
-    discoverAttributes(params).foreach(a => {
-      if (a._1 == "") {
-        error("Empty attribute name")
-      } else if (item.getAttributes.size < 256) {
-        item.put(a._1, a._2, a._3)
+    discoverAttributes(params).foreach { case (name, attr) => {
+      if (name == "") {
+        throw new EmptyAttributeNameException
+      } else if (item.getAttributes.size + attr.values.size < 256) {
+        item.put(name, attr.values, attr.replace)
       } else {
-        error("Too many attributes")
+        throw new NumberItemAttributesExceededException
       }
-    })
+    }}
 
     <PutAttributesResponse xmlns={namespace}>
       {responseMetaData}
     </PutAttributesResponse>
   }
 
-  private def discoverAttributes(params: Params): List[(String, String, Boolean)] = {
-    val attrs = new ListBuffer[(String, String, Boolean)]()
+  private def discoverAttributes(params: Params): LinkedHashMap[String, AttributeUpdate] = {
+    val attrs = new LinkedHashMap[String, AttributeUpdate]
     var i = 0
     var stop = false
     while (!stop) {
@@ -40,12 +41,25 @@ class PutAttributes(data: Data) extends Action(data) with ConditionalChecking {
         if (i > 1) stop = true
       } else {
         if (attrs find (a => a._1 == attrName.get && a._2 == attrValue.get) isEmpty) {
-          attrs += ((attrName.get, attrValue.get, attrReplace.getOrElse("false").toBoolean))
+          val replace = attrReplace.getOrElse("false").toBoolean
+          val attr = attrs.getOrElseUpdate(attrName.get, new AttributeUpdate(replace))
+          attr.values += attrValue.get
         }
       }
       i += 1
     }
-    attrs.toList
+    attrs
   }
-
 }
+
+class AttributeUpdate(val replace: Boolean) {
+  val values = new ListBuffer[String]()
+}
+
+class NumberItemAttributesExceededException extends SDBException("NumberItemAttributesExceeded", "Too many attributes in this item", 409)
+
+class EmptyAttributeNameException
+  extends SDBException("InvalidParameterValue", "Value () for parameter Name is invalid.The empty string is an illegal attribute name")
+
+class MissingItemNameException
+  extends SDBException("MissingParameter", "The request must contain the parameter ItemName.")

--- a/src/test/scala/fakesdb/AbstractFakeSdbTest.scala
+++ b/src/test/scala/fakesdb/AbstractFakeSdbTest.scala
@@ -21,7 +21,7 @@ abstract class AbstractFakeSdbTest {
   AbstractFakeSdbTest.jetty
   // typica does not respect ports 9999
   // val sdb = new SimpleDB(System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_ACCESS_KEY"), false)
-  val sdb = new SimpleDB("ignored", "ignored", false, "127.0.0.1")
+  val sdb = new SimpleDB("ignored", "ignored", false, "127.0.0.1", 8080)
   val domaina = sdb.getDomain("domaina")
 
   @Before

--- a/src/test/scala/fakesdb/PutAttributesTest.scala
+++ b/src/test/scala/fakesdb/PutAttributesTest.scala
@@ -45,7 +45,7 @@ class PutAttributesTest extends AbstractFakeSdbTest {
   @Test
   def testLimitInTwoRequests(): Unit = {
     add(domaina, "itema", "a" -> "1", "b" -> "1")
-    assertFails("InternalError", "Too many attributes", {
+    assertFails("NumberItemAttributesExceeded", "Too many attributes in this item", {
       addLots("itema", 255)
     })
     val attrs = domaina.getItem("itema").getAttributes
@@ -54,7 +54,7 @@ class PutAttributesTest extends AbstractFakeSdbTest {
 
   @Test
   def testLimitInOneRequest(): Unit = {
-    assertFails("InternalError", "Too many attributes", {
+    assertFails("NumberItemAttributesExceeded", "Too many attributes in this item", {
       addLots("itema", 257)
     })
     val attrs = domaina.getItem("itema").getAttributes
@@ -63,7 +63,7 @@ class PutAttributesTest extends AbstractFakeSdbTest {
 
   @Test
   def testFailEmptyAttributeName(): Unit = {
-    assertFails("InternalError", "Empty attribute name", {
+    assertFails("InvalidParameterValue", "Value () for parameter Name is invalid.The empty string is an illegal attribute name", {
       add(domaina, "itema", "" -> "1")
     })
   }

--- a/src/test/scala/fakesdb/SelectParserTest.scala
+++ b/src/test/scala/fakesdb/SelectParserTest.scala
@@ -47,7 +47,9 @@ class SelectParserTest {
     assertEquals(("itema", List(("b", "2"))), results2(0))
   }
 
-  @Test
+  // This behavior is incorrect --
+  // http://docs.amazonwebservices.com/AmazonSimpleDB/latest/DeveloperGuide/index.html?SDB_API_PutAttributes.html
+  ///@Test
   def testFromWithOneAttributeWithMultipleValues(): Unit = {
     domaina.getOrCreateItem("itema").put("a", "1", true)
     domaina.getOrCreateItem("itema").put("a", "1", false)
@@ -215,12 +217,11 @@ class SelectParserTest {
   @Test
   def testWhereEvery(): Unit = {
     domaina.getOrCreateItem("itema").put("a", "1", true)
-    domaina.getOrCreateItem("itema").put("a", "1", false)
     domaina.getOrCreateItem("itemb").put("a", "1", true)
     domaina.getOrCreateItem("itemb").put("a", "2", true)
     val results = SelectParser.makeSelectEval("select * from domaina where every(a) = '1'").select(data)
     assertEquals(1, results.size)
-    assertEquals(("itema", List(("a", "1"), ("a", "1"))), results(0))
+    assertEquals(("itema", List(("a", "1"))), results(0))
   }
 
   @Test


### PR DESCRIPTION
Hey Stephen,

  I noticed the FakeSDB behavior for multi-attribute puts is not consistent with SDB...  with SDB if you do:

put("a", "1", replace=true)
put("a", "2", replace=true)
put("a", "3", replace=true)

in the same request, the new value of "a" will be (1, 2, 3) -- that is, the first replace=true causes the current values to get wiped, but subsequent ones for the same name don't cause previous values from that same request to get erased.... this makes it easy to replace sets of items...

I also changed the values to be stored in a HashSet -- according to the docs for PutAttributes, you can't have the same value listed twice for the same name.... ("a", "1"), ("a", "1") is not valid....

I also cleaned up a couple more errors to match the SDB error codes list... 

Lemme know what you think....
