### PR TITLE
Add <Stacktrace> element as part of error response to help diagnosis

### DIFF
--- a/src/main/scala/fakesdb/FakeSdbServlet.scala
+++ b/src/main/scala/fakesdb/FakeSdbServlet.scala
@@ -1,5 +1,6 @@
 package fakesdb
 
+import java.io.{PrintWriter, StringWriter}
 import javax.servlet.http._
 import fakesdb.actions._
 
@@ -50,9 +51,13 @@ class FakeSdbServlet extends HttpServlet {
       case _ => "InternalError"
     }
 
+    val stacktrace = new StringWriter()
+    t.printStackTrace(new PrintWriter(stacktrace))
+
     <Response>
-      <Errors><Error><Code>{xmlCode}</Code><Message>{t.getMessage}</Message><BoxUsage>0</BoxUsage></Error></Errors>
+      <Errors><Error><Code>{xmlCode}</Code><Message>{t.getClass.getName}: {t.getMessage}</Message><BoxUsage>0</BoxUsage></Error></Errors>
       <RequestId>0</RequestId>
+      <Stacktrace>{stacktrace.toString}</Stacktrace>
     </Response>
   }
 


### PR DESCRIPTION
I don't know if this is generally useful or if it's even valid to add the <Stacktrace> element in the response but it was pretty useful for me :)

Turns out fakesdb-testing-2.5.jar didn't include the AWS SDK classes and so it was internally throwing ClassNotFoundException and failing tests in simplistic.  This made debugging a lot simpler than logging stuff via log4j on the fakesdb side.
