### PR TITLE
tweaks for scala 2.10

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,10 +1,11 @@
+Buildr.settings.build['scala.version'] = '2.10.0'
+
 require 'buildr/ivy_extension'
 require 'buildr/scala'
 require 'fakesdb'
 
 VERSION_NUMBER = '2.6-SNAPSHOT'
 
-Buildr.settings.build['scala.version'] = '2.9.1'
 
 repositories.remote << "http://mirrors.ibiblio.org/maven2"
 repositories.release_to = 'sftp://joist.ws/var/www/joist.repo'
@@ -16,8 +17,6 @@ define FakeSDB::fakesdb do
   project.version = VERSION_NUMBER
   project.group = 'com.bizo'
   ivy.compile_conf(['servlet', 'war', 'buildtime']).test_conf('test')
-
-  project.scalac_options.incremental = true
 
   test.using :junit
 
@@ -33,7 +32,7 @@ define FakeSDB::fakesdb do
   end
 
   all_in_one_jar :id   => "standalone",
-                 :libs => ["aws-java-sdk", "jetty", "servlet-api", "scala-library"]
+                 :libs => ["aws-java-sdk", "jetty", "servlet-api", "scala-library", "scala-reflect"]
 
   # without scala-library
   all_in_one_jar :id => "testing",

--- a/ivy.xml
+++ b/ivy.xml
@@ -13,7 +13,8 @@
       <artifact name="fakesdb-servlet" type="jar" ext="jar" conf="servlet"/>
     </publications>
     <dependencies>
-        <dependency org="org.scala-lang" name="scala-library" rev="2.9.0-1" conf="servlet->default;sources->sources"/>
+        <dependency org="org.scala-lang" name="scala-library" rev="2.10.0" conf="servlet->default;sources->sources"/>
+        <dependency org="org.scala-lang" name="scala-reflect" rev="2.10.0" conf="servlet->default;sources->sources"/>
         <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.3.21.1" conf="servlet->default;sources->sources"/>
 
         <dependency org="servletapi" name="servletapi" rev="2.4" conf="buildtime->default"/>


### PR DESCRIPTION
FYI, tweaks to produce scala 2.10 packages.

Currently requires buildr-trunk (01/23/2013+).
